### PR TITLE
Added support for version ^4.0 for vlucas/phpdotenv

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
    "require": {
     "php": "^7.0|^7.1|^7.2",
     "guzzlehttp/guzzle": "5.*|6.*",
-    "vlucas/phpdotenv": "^2.2|^3.6"
+    "vlucas/phpdotenv": "^2.2|^3.6|^4.0"
    },
    "require-dev": {
         "phpunit/phpunit" : "4.*",


### PR DESCRIPTION
This PR only adds support for version ^4.0 of the vlucas/phpdotenv package as the jusibe-php-lib package cannot be installed on a Laravel 7.19.0 project due the Composer dependency error shown below:

```bash
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Conclusion: don't install unicodeveloper/jusibe-php-lib 1.0.3
    - Conclusion: don't install unicodeveloper/jusibe-php-lib 1.0.2
    - Conclusion: don't install unicodeveloper/jusibe-php-lib 1.0.1
    - Conclusion: remove laravel/framework v7.19.1
    - Installation request for vlucas/phpdotenv (locked at v4.1.7) -> satisfiable by vlucas/phpdotenv[v4.1.7].
    - Installation request for unicodeveloper/jusibe-php-lib ^1.0 -> satisfiable by unicodeveloper/jusibe-php-lib[1.0.0, 1.0.1, 1.0.2, 1.0.3].
    - Conclusion: don't install laravel/framework v7.19.1
    - unicodeveloper/jusibe-php-lib 1.0.0 requires illuminate/support 5.* -> satisfiable by illuminate/support[5.0.x-dev, 5.1.x-dev, 5.2.x-dev, 5.3.x-dev, 5.4.x-dev, 5.5.x-dev, 5.6.x-dev, 5.7.17, 5.7.18, 5.7.19, 5.7.x-dev, 5.8.x-dev, v5.0.0, v5.0.22, v5.0.25, v5.0.26, v5.0.28, v5.0.33, v5.0.4, v5.1.1, v5.1.13, v5.1.16, v5.1.2, v5.1.20, v5.1.22, v5.1.25, v5.1.28, v5.1.30, v5.1.31, v5.1.41, v5.1.6, v5.1.8, v5.2.0, v5.2.19, v5.2.21, v5.2.24, v5.2.25, v5.2.26, v5.2.27, v5.2.28, v5.2.31, v5.2.32, v5.2.37, v5.2.43, v5.2.45, v5.2.6, v5.2.7, v5.3.0, v5.3.16, v5.3.23, v5.3.4, v5.4.0, v5.4.13, v5.4.17, v5.4.19, v5.4.27, v5.4.36, v5.4.9, v5.5.0, v5.5.16, v5.5.17, v5.5.2, v5.5.28, v5.5.33, v5.5.34, v5.5.35, v5.5.36, v5.5.37, v5.5.39, v5.5.40, v5.5.41, v5.5.43, v5.5.44, v5.6.0, v5.6.1, v5.6.10, v5.6.11, v5.6.12, v5.6.13, v5.6.14, v5.6.15, v5.6.16, v5.6.17, v5.6.19, v5.6.2, v5.6.20, v5.6.21, v5.6.22, v5.6.23, v5.6.24, v5.6.25, v5.6.26, v5.6.27, v5.6.28, v5.6.29, v5.6.3, v5.6.30, v5.6.31, v5.6.32, v5.6.33, v5.6.34, v5.6.35, v5.6.36, v5.6.37, v5.6.38, v5.6.39, v5.6.4, v5.6.5, v5.6.6, v5.6.7, v5.6.8, v5.6.9, v5.7.0, v5.7.1, v5.7.10, v5.7.11, v5.7.15, v5.7.2, v5.7.20, v5.7.21, v5.7.22, v5.7.23, v5.7.26, v5.7.27, v5.7.28, v5.7.3, v5.7.4, v5.7.5, v5.7.6, v5.7.7, v5.7.8, v5.7.9, v5.8.0, v5.8.11, v5.8.12, v5.8.14, v5.8.15, v5.8.17, v5.8.18, v5.8.19, v5.8.2, v5.8.20, v5.8.22, v5.8.24, v5.8.27, v5.8.28, v5.8.29, v5.8.3, v5.8.30, v5.8.31, v5.8.32, v5.8.33, v5.8.34, v5.8.35, v5.8.36, v5.8.4, v5.8.8, v5.8.9], laravel/framework[5.3.x-dev, 5.4.x-dev, 5.5.x-dev, 5.6.x-dev, 5.7.x-dev, 5.8.x-dev].
```